### PR TITLE
feat: 페이지 레이아웃 설계

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,19 +3,86 @@
 @tailwind utilities;
 
 :root {
-  --background: #171a20;
-  --foreground: #ffffff;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --background: #ffffff;
-    --foreground: #171a20;
-  }
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  --color-BadgeBg: rgba(240, 185, 11, 0.1);
+  --color-ErrorBg: rgba(246, 70, 93, 0.1);
+  --color-TwoColorIcon: #CACED3;
+  --color-ToastBg: #707A8A;
+  --color-Placeholder: #474D57;
+  --color-Grid: #2B3139;
+  --color-TagBg: #474D57;
+  --color-Success: #2EBD85;
+  --color-SuccessBg: #102821;
+  --color-Error: #F6465D;
+  --color-TextBuy: #2EBD85;
+  --color-Buy: #2EBD85;
+  --color-BuyHover: #32D993;
+  --color-DepthBuyBg: #102821;
+  --color-TextSell: #F6465D;
+  --color-Sell: #F6465D;
+  --color-SellHover: #FF707E;
+  --color-DepthSellBg: #35141D;
+  --color-TextToast: #A37200;
+  --color-TradeBg: #0B0E11;
+  --color-TextLink: #F0B90B;
+  --color-PrimaryYellow: #F0B90B;
+  --color-BtnBg: #FCD535;
+  --color-LiteBg2: #191A1F;
+  --color-LiteBg1: #202630;
+  --color-IconNormal: #848E9C;
+  --color-TextOnYellow: #202630;
+  --color-TextOnGray: #EAECEF;
+  --color-EmphasizeText: #FF693D;
+  --color-RedGreenBgText: #FFFFFF;
+  --color-PrimaryText: #EAECEF;
+  --color-SecondaryText: #B7BDC6;
+  --color-TertiaryText: #848E9C;
+  --color-DisableText: #5E6673;
+  --color-DisabledText: #5E6673;
+  --color-DisableBtn: #2B3139;
+  --color-Line: #2B3139;
+  --color-Vessel: #1E2329;
+  --color-CardBg: #1E2329;
+  --color-InputLine: #474D57;
+  --color-Input: #2B3139;
+  --color-SecondaryBg: #0B0E11;
+  --color-BasicBg: #181A20;
+  --color-gradientPrimary: linear-gradient(295.27deg, #15141A 0%, #474D57 84.52%);
+  --color-gradientBrand: linear-gradient(180deg, #F8D12F 0%, #F0B90B 100%);
+  --color-selectedBg: #1E2026;
+  --color-badgeBg: #2D2A20;
+  --color-popupBg: #1E2329;
+  --color-bg7: #191A1F;
+  --color-bg6: #202630;
+  --color-bg4: #5E6673;
+  --color-bg3: #2B3139;
+  --color-bg2: #0B0E11;
+  --color-bg1: #181A20;
+  --color-bg: #181A20;
+  --color-textToast: #A37200;
+  --color-textBrand: #F0B90B;
+  --color-textDisabled: #5E6673;
+  --color-textThird: #848E9C;
+  --color-textSecondary: #B7BDC6;
+  --color-textPrimary: #EAECEF;
+  --color-textBlack: #0B0E11;
+  --color-textGray: #EAECEF;
+  --color-textWhite: #FFFFFF;
+  --color-iconNormal: #848E9C;
+  --color-disable: #474D57;
+  --color-successBg: #102821;
+  --color-success: #0ECB81;
+  --color-errorBg: #35141D;
+  --color-error: #F6465D;
+  --color-primaryHover: #F0B90B;
+  --color-primary: #FCD535;
+  --color-outlineHover: #6A4403;
+  --color-line: #2B3139;
+  --color-depthBuyBg: #102821;
+  --color-buyHover: #32D993;
+  --color-textBuy: #0ECB81;
+  --color-buy: #0ECB81;
+  --color-depthSellBg: #35141D;
+  --color-sellHover: #FF707E;
+  --color-textSell: #F6465D;
+  --color-sell: #F6465D;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 
   return (
     <html lang="en" className={binancePlexVariables}>
-      <body className="antialiased">{children}</body>
+      <body className="antialiased font-binancePlex">{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,18 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="font-[family-name:var(--font-binance-plex-regular)]">
-      <div className="flex flex-col items-center justify-center">
-        <h1 className="text-4xl font-bold">Binance Plex Font Test</h1>
-        <Image
-          src="/images/logo.png"
-          alt="Binance Plex Logo"
-          width={100}
-          height={100}
-        />
-      </div>
+    <div className="flex flex-col items-center justify-center bg-[var(--color-TradeBg)] text-[var(--color-textPrimary)]">
+      <Link href="/trade/BTCUSDT">
+        <h1 className="text-4xl font-bold underline">Binance Plex Font Test</h1>
+      </Link>
+      <Image
+        src="/images/logo.png"
+        alt="Binance Plex Logo"
+        width={100}
+        height={100}
+      />
     </div>
   );
 }

--- a/src/app/trade/[symbol]/_components/Chart.tsx
+++ b/src/app/trade/[symbol]/_components/Chart.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function Chart() {
+  return <Card style={{ gridArea: "chart" }}>Chart</Card>;
+}

--- a/src/app/trade/[symbol]/_components/Footer.tsx
+++ b/src/app/trade/[symbol]/_components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="fixed bottom-0 w-full bg-[var(--color-BasicBg)] border-t-4 border-[var(--color-TradeBg)] rounded-md">
+      Footer
+    </footer>
+  );
+}

--- a/src/app/trade/[symbol]/_components/Market.tsx
+++ b/src/app/trade/[symbol]/_components/Market.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function Market() {
+  return <Card style={{ gridArea: "market" }}>Market</Card>;
+}

--- a/src/app/trade/[symbol]/_components/MarketActivity.tsx
+++ b/src/app/trade/[symbol]/_components/MarketActivity.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function MarketActivity() {
+  return <Card style={{ gridArea: "marketActivity" }}>MarketActivity</Card>;
+}

--- a/src/app/trade/[symbol]/_components/OrderBook.tsx
+++ b/src/app/trade/[symbol]/_components/OrderBook.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function OrderBook() {
+  return <Card style={{ gridArea: "orderbook" }}>OrderBook</Card>;
+}

--- a/src/app/trade/[symbol]/_components/Orderform.tsx
+++ b/src/app/trade/[symbol]/_components/Orderform.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function Orderform() {
+  return <Card style={{ gridArea: "orderform" }}>Orderform</Card>;
+}

--- a/src/app/trade/[symbol]/_components/SubHeader.tsx
+++ b/src/app/trade/[symbol]/_components/SubHeader.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function SubHeader() {
+  return <Card style={{ gridArea: "subHeader" }}>SubHeader</Card>;
+}

--- a/src/app/trade/[symbol]/_components/Trades.tsx
+++ b/src/app/trade/[symbol]/_components/Trades.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function Trades() {
+  return <Card style={{ gridArea: "trades" }}>Trades</Card>;
+}

--- a/src/app/trade/[symbol]/_components/UserInfo.tsx
+++ b/src/app/trade/[symbol]/_components/UserInfo.tsx
@@ -1,0 +1,5 @@
+import Card from "@/components/card/Card";
+
+export default function UserInfo() {
+  return <Card style={{ gridArea: "userInfo" }}>UserInfo</Card>;
+}

--- a/src/app/trade/[symbol]/layout.tsx
+++ b/src/app/trade/[symbol]/layout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import Header from "@/components/layout/Header";
+import PageLayout from "@/components/layout/PageLayout";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <PageLayout
+      header={
+        <Header>
+          <Header.Logo />
+        </Header>
+      }
+    >
+      {children}
+    </PageLayout>
+  );
+}

--- a/src/app/trade/[symbol]/page.tsx
+++ b/src/app/trade/[symbol]/page.tsx
@@ -1,14 +1,44 @@
-import Header from "@/components/layout/Header";
-import PageLayout from "@/components/layout/PageLayout";
+import Chart from "./_components/Chart";
+import Footer from "./_components/Footer";
+import Market from "./_components/Market";
+import MarketActivity from "./_components/MarketActivity";
+import OrderBook from "./_components/OrderBook";
+import Orderform from "./_components/Orderform";
+import SubHeader from "./_components/SubHeader";
+import Trades from "./_components/Trades";
+import UserInfo from "./_components/UserInfo";
 
 export default function Page() {
   return (
-    <PageLayout
-      header={
-        <Header>
-          <Header.Logo />
-        </Header>
-      }
-    ></PageLayout>
+    <main className="relative flex justify-center bg-[var(--color-TradeBg)]">
+      <div
+        className="grid gap-1 m-1 border-[var(--color-TradeBg)]"
+        style={{
+          gridTemplateColumns:
+            "minmax(253px, 320px) minmax(300px, 880px) minmax(253px, 320px)",
+          gridTemplateRows:
+            "56px 360px 160px minmax(169px, 1fr) minmax(146px, auto) 560px 24px",
+          gridTemplateAreas: `
+          "subHeader subHeader market"
+          "orderbook chart market"
+          "orderbook chart trades"
+          "orderbook orderform trades"
+          "orderbook orderform marketActivity"
+          "userInfo userInfo userInfo"
+        `,
+        }}
+      >
+        <SubHeader />
+        <OrderBook />
+        <Chart />
+        <Market />
+        <Trades />
+        <Orderform />
+        <MarketActivity />
+        <UserInfo />
+      </div>
+
+      <Footer />
+    </main>
   );
 }

--- a/src/app/trade/[symbol]/page.tsx
+++ b/src/app/trade/[symbol]/page.tsx
@@ -1,0 +1,14 @@
+import Header from "@/components/layout/Header";
+import PageLayout from "@/components/layout/PageLayout";
+
+export default function Page() {
+  return (
+    <PageLayout
+      header={
+        <Header>
+          <Header.Logo />
+        </Header>
+      }
+    ></PageLayout>
+  );
+}

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from "react";
+
+interface CardWrapperProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export default function Card({
+  children,
+  className,
+  style,
+}: PropsWithChildren<CardWrapperProps>) {
+  return (
+    <div
+      className={`bg-[var(--color-BasicBg)] p-4 rounded-md ${className}`}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+const HeaderLogo = () => {
+  return (
+    <Link href="/">
+      <Image
+        src={"/images/binance-h.png"}
+        alt="Binance Plex Logo"
+        width={120}
+        height={64}
+      />
+    </Link>
+  );
+};
+
+const Header = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => {
+  return (
+    <div
+      className={`flex h-[64px] items-center justify-between bg-[var(--color-BasicBg)] px-6 ${className}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+Header.Logo = HeaderLogo;
+
+export default Header;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ const Header = ({
 }) => {
   return (
     <div
-      className={`flex h-[64px] items-center justify-between bg-[var(--color-BasicBg)] px-6 ${className}`}
+      className={`flex h-[64px] shrink-0 items-center justify-between bg-[var(--color-BasicBg)] px-6 ${className}`}
     >
       {children}
     </div>

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren, ReactNode } from "react";
+
+interface PageLayoutProps {
+  className?: string;
+  header: ReactNode;
+  footer?: ReactNode;
+}
+
+const PageLayout = ({
+  header,
+  children,
+  className,
+}: PropsWithChildren<PageLayoutProps>) => {
+  return (
+    <>
+      <main
+        className={`h-screen flex flex-col bg-[var(--color-TradeBg)] text-[var(--color-textPrimary)] ${
+          className || ""
+        }`}
+      >
+        {header}
+        {children}
+      </main>
+    </>
+  );
+};
+
+export default PageLayout;

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -12,16 +12,14 @@ const PageLayout = ({
   className,
 }: PropsWithChildren<PageLayoutProps>) => {
   return (
-    <>
-      <main
-        className={`h-screen flex flex-col bg-[var(--color-TradeBg)] text-[var(--color-textPrimary)] ${
-          className || ""
-        }`}
-      >
-        {header}
-        {children}
-      </main>
-    </>
+    <div
+      className={`min-h-screen flex flex-col bg-[var(--color-TradeBg)] text-[var(--color-textPrimary)] ${
+        className || ""
+      }`}
+    >
+      {header}
+      {children}
+    </div>
   );
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,9 +8,8 @@ export default {
   ],
   theme: {
     extend: {
-      colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+      fontFamily: {
+        binancePlex: ["var(--font-binance-plex-regular)"],
       },
     },
   },


### PR DESCRIPTION
## 페이지 레이아웃 설계
### 개요
- 작업 시간: 5시 10분~7시 10분 (2시간)
- 작업:
    - en/trade/BTCUSDT: 페이지 추가(제시된 경로)
    - layout 요소(partial) 컴포넌트 추가
       - PageLayout.tsx, Header.tsx 작성
    - /trade/[symbol] 페이지 추가
       - grid CSS 작성
       - Card 컴포넌트 추가
    - CSS 변수 업데이트


### 리뷰어에게 전할 내용
- 다국어 prefix는 추후에 코드상으로 구현할 것으로 예상하고, en을 제외한 /trade/[symbol] 폴더 내에 작성했습니다.
- GNB(Header.tsx)는 다른 url에서는 다른 형태를 가진 것으로 보여, 각 경로의 page.tsx에서 컴파운드 컴포넌트로 사용하도록 작성했습니다.
- 반응형 작업이 구현 필수 요건에 포함되지 않는 것으로 보여, 데스크탑 기준으로 작업했습니다

### 스크린샷
![image](https://github.com/user-attachments/assets/cc04d8b6-243e-4738-8a01-d80d076163de)

