### PR TITLE
feat: Chart 퍼블리싱

### DIFF
--- a/src/app/trade/[symbol]/_components/Chart.tsx
+++ b/src/app/trade/[symbol]/_components/Chart.tsx
@@ -1,5 +1,39 @@
+"use client";
+
 import { Card } from "@/components/card/Card";
+import { useState } from "react";
 
 export default function Chart() {
-  return <Card style={{ gridArea: "chart" }}>Chart</Card>;
+  const [selected, setSelected] = useState("Chart");
+  const [subSelected, setSubSelected] = useState("Time");
+
+  return (
+    <Card
+      style={{ gridArea: "chart" }}
+      header={
+        <>
+          <Card.Header>
+            <Card.Tabs
+              list={["Chart", "Info", "Tranding Data", "Square"]}
+              selected={selected}
+              setSelected={setSelected}
+            >
+              <Card.TabList />
+            </Card.Tabs>
+          </Card.Header>
+
+          <Card.Header>
+            <Card.Tabs
+              list={["Time", "1s", "15m", "1H", "4H", "1D", "1W"]}
+              selected={subSelected}
+              setSelected={setSubSelected}
+              subHeader
+            >
+              <Card.TabList />
+            </Card.Tabs>
+          </Card.Header>
+        </>
+      }
+    ></Card>
+  );
 }

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, ReactNode } from "react";
+"use client";
+import { createContext, PropsWithChildren, ReactNode, useContext } from "react";
 
 interface CardWrapperProps {
   className?: string;
@@ -11,6 +12,93 @@ function Header({ children }: { children: ReactNode }) {
     <header className="h-10 flex items-center justify-between px-4 text-sm font-bold border-b border-[var(--color-line)]">
       {children}
     </header>
+  );
+}
+
+function SubHeader({ children }: { children: ReactNode }) {
+  return (
+    <div className="h-10 flex items-center justify-between px-4 text-sm font-bold">
+      {children}
+    </div>
+  );
+}
+
+const TabListContext = createContext<{
+  selected: string;
+  setSelected: (selected: string) => void;
+  list: string[];
+  subHeader?: boolean;
+}>({ selected: "", setSelected: () => {}, list: [], subHeader: false });
+
+function Tabs({
+  className,
+  children,
+  ...props
+}: {
+  list: string[];
+  selected: string;
+  setSelected: (selected: string) => void;
+  subHeader?: boolean;
+  className?: string;
+  children?: ReactNode;
+}) {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLDivElement;
+    props.setSelected(target.innerText);
+  };
+
+  return (
+    <TabListContext.Provider value={props}>
+      <div
+        className={`h-full flex ${
+          props.subHeader ? "gap-2" : "gap-6"
+        } ${className}`}
+        onClick={(e) => handleClick(e)}
+      >
+        {children}
+      </div>
+    </TabListContext.Provider>
+  );
+}
+
+function TabList() {
+  const { selected, list, subHeader } = useContext(TabListContext);
+
+  const TabComponent = subHeader ? SubTab : Tab;
+
+  return (
+    <>
+      {list.map((item) => (
+        <TabComponent key={item} item={item} isSelected={selected === item} />
+      ))}
+    </>
+  );
+}
+
+function Tab({ item, isSelected }: { item: string; isSelected: boolean }) {
+  return (
+    <div
+      className={`relative flex items-center justify-between text-sm font-bold cursor-pointer text-[var(--color-TertiaryText)] hover:text-[var(--color-PrimaryText)] transition-colors duration-300 ${
+        isSelected ? "text-[var(--color-PrimaryText)]" : ""
+      }`}
+    >
+      {item}
+      {isSelected && (
+        <div className="w-4 absolute bottom-0 left-1/2 -translate-x-1/2 h-[3px] bg-[var(--color-PrimaryYellow)]" />
+      )}
+    </div>
+  );
+}
+
+function SubTab({ item, isSelected }: { item: string; isSelected: boolean }) {
+  return (
+    <div
+      className={`relative flex items-center justify-between text-xs font-bold cursor-pointer text-[var(--color-TertiaryText)] hover:text-[var(--color-PrimaryText)] transition-colors duration-300 ${
+        isSelected ? "text-[var(--color-PrimaryText)]" : ""
+      }`}
+    >
+      {item}
+    </div>
   );
 }
 
@@ -32,5 +120,9 @@ function Card({
 }
 
 Card.Header = Header;
+Card.SubHeader = SubHeader;
+
+Card.Tabs = Tabs;
+Card.TabList = TabList;
 
 export { Card };


### PR DESCRIPTION
- 차트를 제외하고 작업 진행
- 헤더의 Tab 리스트, SubTab 리스트 구현

```tsx
header={
  <>
    <Card.Header>
      <Card.Tabs
        list={["Chart", "Info", "Tranding Data", "Square"]}
        selected={selected}
        setSelected={setSelected}
      >
        <Card.TabList />
      </Card.Tabs>
    </Card.Header>

    <Card.Header>
      <Card.Tabs
        list={["Time", "1s", "15m", "1H", "4H", "1D", "1W"]}
        selected={subSelected}
        setSelected={setSubSelected}
        subHeader
      >
        <Card.TabList />
      </Card.Tabs>
    </Card.Header>
  </>
}
```
![image](https://github.com/user-attachments/assets/ba78b7fa-57df-43f3-a1ad-72a01ebedb1b)
