### PR TITLE
feat: OrderBook 클릭 기능 구현

### DIFF
--- a/src/app/trade/[symbol]/_components/OrderBook.tsx
+++ b/src/app/trade/[symbol]/_components/OrderBook.tsx
@@ -2,102 +2,20 @@
 import { useState } from "react";
 import { Card } from "@/components/card/Card";
 import MeatBall from "@/assets/icons/svg-57.svg";
+import type {
+  OrderBookFilter as OrderBookFilterType,
+} from "@/types/order";
 import OrderBookFilter from "./OrderBook/OrderBookFilter";
 import OrderBookItemHeader from "./OrderBook/OrderBookItemHeader";
 import OrderBookList from "./OrderBook/OrderBookList";
+import useSelectOrderContent from "../_hooks/useSelectOrderContent";
+import DUMMY_LIST from "../dummyData.json";
 
-export type OrderBookFilterType = "all" | "buy" | "sell";
-export interface OrderBookItem {
-  price: number;
-  amount: number;
-  total: number;
-}
-
-const DUMMY_LIST = {
-  buy: [
-    { price: 96211.23, amount: 0.07903, total: 7600 },
-    { price: 96210.14, amount: 0.05075, total: 4880 },
-    { price: 96209.76, amount: 0.00257, total: 247.25908 },
-    { price: 96209.75, amount: 0.07687, total: 7400 },
-    { price: 96209.74, amount: 0.3116, total: 29980 },
-    { price: 96209.26, amount: 0.85818, total: 82560 },
-    { price: 96208.67, amount: 0.23061, total: 22190 },
-    { price: 96208.66, amount: 0.07422, total: 7140 },
-    { price: 96208.01, amount: 0.29611, total: 28490 },
-    { price: 96208.0, amount: 0.0094, total: 904.3552 },
-    { price: 96207.55, amount: 0.51949, total: 49980 },
-    { price: 96207.54, amount: 0.00006, total: 5.77245 },
-    { price: 96206.9, amount: 0.38539, total: 37080 },
-    { price: 96206.89, amount: 0.54, total: 51950 },
-    { price: 96206.34, amount: 0.29499, total: 28380 },
-    { price: 96205.81, amount: 0.07583, total: 7300 },
-    { price: 96205.76, amount: 0.09886, total: 9510 },
-    { price: 96205.75, amount: 0.00054, total: 51.9511 },
-    { price: 96205.51, amount: 0.07268, total: 6990 },
-    { price: 96205.5, amount: 0.15686, total: 15090 },
-    { price: 96205.33, amount: 0.08106, total: 7800 },
-    { price: 96205.05, amount: 0.52386, total: 50400 },
-    { price: 96205.03, amount: 0.25974, total: 24990 },
-    { price: 96204.76, amount: 0.06544, total: 6300 },
-    { price: 96204.31, amount: 0.002, total: 192.40862 },
-    { price: 96204.2, amount: 0.0001, total: 9.62042 },
-    { price: 96204.19, amount: 0.00007, total: 6.73429 },
-    { price: 96204.06, amount: 0.08103, total: 7800 },
-    { price: 96204.05, amount: 0.00085, total: 81.77344 },
-    { price: 96204.03, amount: 0.33843, total: 32560 },
-    { price: 96204.0, amount: 0.0094, total: 904.3176 },
-    { price: 96203.94, amount: 0.00008, total: 7.69632 },
-    { price: 96203.69, amount: 0.05365, total: 5160 },
-    { price: 96203.61, amount: 0.07687, total: 7400 },
-    { price: 96202.73, amount: 0.00006, total: 5.77216 },
-    { price: 96202.42, amount: 0.08103, total: 7800 },
-    { price: 96202.4, amount: 0.09696, total: 9330 },
-    { price: 96202.18, amount: 0.00008, total: 7.69617 },
-    { price: 96202.01, amount: 0.14227, total: 13690 },
-    { price: 96200.83, amount: 0.00013, total: 12.50611 },
-  ],
-  sell: [
-    { price: 96274.63, amount: 0.20752, total: 19980 },
-    { price: 96274.56, amount: 0.25974, total: 25010 },
-    { price: 96274.17, amount: 0.15226, total: 14660 },
-    { price: 96273.44, amount: 0.00008, total: 7.70188 },
-    { price: 96272.3, amount: 0.37214, total: 35830 },
-    { price: 96272.0, amount: 0.1087, total: 10460 },
-    { price: 96271.48, amount: 0.00011, total: 10.58986 },
-    { price: 96270.79, amount: 0.01038, total: 999.2908 },
-    { price: 96270.66, amount: 0.00006, total: 5.77624 },
-    { price: 96270.08, amount: 0.00006, total: 5.7762 },
-    { price: 96269.97, amount: 0.04, total: 3850 },
-    { price: 96269.85, amount: 0.07824, total: 7530 },
-    { price: 96268.56, amount: 0.0308, total: 2970 },
-    { price: 96268.34, amount: 0.00061, total: 58.72369 },
-    { price: 96268.0, amount: 0.0993, total: 9560 },
-    { price: 96267.99, amount: 0.00008, total: 7.70144 },
-    { price: 96267.36, amount: 0.30873, total: 29720 },
-    { price: 96266.33, amount: 0.2386, total: 22970 },
-    { price: 96266.32, amount: 0.00024, total: 23.10392 },
-    { price: 96265.27, amount: 0.00006, total: 5.77592 },
-    { price: 96264.72, amount: 0.2, total: 19250 },
-    { price: 96264.71, amount: 0.0003, total: 28.87941 },
-    { price: 96264.02, amount: 0.03642, total: 3510 },
-    { price: 96264.0, amount: 0.09938, total: 9570 },
-    { price: 96263.99, amount: 0.00024, total: 23.10336 },
-    { price: 96263.98, amount: 0.00024, total: 23.10336 },
-    { price: 96263.97, amount: 0.0001, total: 9.6264 },
-    { price: 96262.96, amount: 0.0001, total: 9.6263 },
-    { price: 96262.12, amount: 0.0001, total: 9.62621 },
-    { price: 96262.11, amount: 0.0001, total: 9.62621 },
-    { price: 96261.05, amount: 0.00006, total: 5.77566 },
-    { price: 96260.66, amount: 0.23511, total: 22630 },
-    { price: 96260.65, amount: 0.00945, total: 909.66314 },
-    { price: 96260.64, amount: 0.00016, total: 15.4017 },
-    { price: 96260.55, amount: 0.12975, total: 12430 },
-    { price: 96260.54, amount: 0.00006, total: 5.77554 },
-    { price: 96260.53, amount: 0.00006, total: 5.77554 },
-  ],
-};
-
-export default function OrderBook() {
+export default function OrderBook({
+  onSelectOrder,
+}: {
+  onSelectOrder: ReturnType<typeof useSelectOrderContent>["handleSelectOrder"];
+}) {
   const [filter, setFilter] = useState<OrderBookFilterType>("all");
 
   return (
@@ -121,7 +39,7 @@ export default function OrderBook() {
       >
         {filter !== "buy" && (
           <div className="max-h-[710px] overflow-y-scroll">
-            <OrderBookList.List type="sell" />
+            <OrderBookList.List type="sell" onSelectOrder={onSelectOrder} />
           </div>
         )}
 
@@ -129,7 +47,7 @@ export default function OrderBook() {
 
         {filter !== "sell" && (
           <div className="max-h-[710px] overflow-y-scroll">
-            <OrderBookList.List type="buy" />
+            <OrderBookList.List type="buy" onSelectOrder={onSelectOrder} />
           </div>
         )}
       </OrderBookList>

--- a/src/app/trade/[symbol]/_components/OrderBook/OrderBookList.tsx
+++ b/src/app/trade/[symbol]/_components/OrderBook/OrderBookList.tsx
@@ -1,11 +1,12 @@
 import { createContext, useContext } from "react";
+import type { OrderItem, OrderBookFilter } from "@/types/order";
 import ArrowDown from "@/assets/icons/svg-18.svg";
-import type { OrderBookItem, OrderBookFilterType } from "../OrderBook";
+import useSelectOrderContent from "../../_hooks/useSelectOrderContent";
 
 interface OrderBookListProps {
   isHigherThanBefore: boolean;
-  list: OrderBookItem[];
-  filter: OrderBookFilterType;
+  list: OrderItem[];
+  filter: OrderBookFilter;
   children: React.ReactNode;
 }
 type OrderBookContextProps = Omit<OrderBookListProps, "children">;
@@ -14,7 +15,13 @@ const OrderBookContext = createContext<OrderBookContextProps | undefined>(
   undefined
 );
 
-function List({ type }: { type: OrderBookFilterType }) {
+function List({
+  type,
+  onSelectOrder,
+}: {
+  type: Exclude<OrderBookFilter, "all">;
+  onSelectOrder: ReturnType<typeof useSelectOrderContent>["handleSelectOrder"];
+}) {
   const context = useContext(OrderBookContext);
   if (!context) return null;
 
@@ -26,14 +33,36 @@ function List({ type }: { type: OrderBookFilterType }) {
     newList = list.slice(0, 17);
   }
 
+  const handleSelectOrder = (
+    e: React.MouseEvent<HTMLDivElement>,
+    item: OrderItem
+  ) => {
+    const target = e.target as HTMLElement;
+    onSelectOrder(
+      item,
+      type,
+      target.dataset.field as "price" | "amount" | "total"
+    );
+  };
+
   return (
-    <ul className="flex flex-col text-xs font-semibold my-1">
+    <ul className="flex flex-col text-xs font-semibold my-1 cursor-pointer">
       {newList.map((item) => {
         return (
-          <div className="flex justify-between py-[2px]" key={item.price}>
-            <p style={{ color }}>{item.price}</p>
-            <p className="flex-1 text-right">{item.amount}</p>
-            <p className="w-24 shrink-0 text-right">{item.total}</p>
+          <div
+            className="flex justify-between py-[2px] opacity-80 hover:opacity-100"
+            key={item.price}
+            onClick={(e) => handleSelectOrder(e, item)}
+          >
+            <p style={{ color }} data-field="price">
+              {item.price}
+            </p>
+            <p className="flex-1 text-right" data-field="amount">
+              {item.amount}
+            </p>
+            <p className="w-24 shrink-0 text-right" data-field="total">
+              {item.total}
+            </p>
           </div>
         );
       })}

--- a/src/app/trade/[symbol]/_components/Orderform.tsx
+++ b/src/app/trade/[symbol]/_components/Orderform.tsx
@@ -1,16 +1,73 @@
 "use client";
 
-import { useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { Card } from "@/components/card/Card";
 import { Tabs } from "@/components/tabs/Tabs";
 import { InputField } from "@/components/input/Input";
 import Button from "@/components/button/Button";
+import type { OrderItem } from "@/types/order";
+import useSelectOrderContent from "../_hooks/useSelectOrderContent";
 
-export default function Orderform() {
+type Order = OrderItem & { type: "sell" | "buy" };
+
+export default function Orderform({
+  selectedOrder,
+}: {
+  selectedOrder: ReturnType<typeof useSelectOrderContent>["selectedOrder"];
+}) {
   const [selected, setSelected] = useState("Spot");
   const [subSelected, setSubSelected] = useState("Limit");
-  const [price, setPrice] = useState(0);
-  const [amount, setAmount] = useState(0);
+  const [orders, setOrders] = useState<Order>();
+  const [sellAmount, setSellAmount] = useState(0);
+  const [buyAmount, setBuyAmount] = useState(0);
+
+  useEffect(() => {
+    if (!selectedOrder) {
+      setSellAmount(0);
+      setBuyAmount(0);
+      return;
+    };
+    setOrders(selectedOrder);
+    setSellAmount(selectedOrder.type === "sell" ? selectedOrder.sumBTC : 0);
+    setBuyAmount(selectedOrder.type === "buy" ? selectedOrder.sumBTC : 0);
+  }, [selectedOrder.price]);
+
+  const renderInputFields = (
+    type: "buy" | "sell",
+    amount: number,
+    setAmount: Dispatch<SetStateAction<number>>,
+  ) => (
+    <>
+      <InputField>
+        <InputField.Label>Price</InputField.Label>
+        <InputField.Number
+          step={0.01}
+          type="number"
+          setValue={(value) =>
+            setOrders((prev) => (
+              prev?.type === type
+                ? { ...prev, price: Number(value) }
+                : prev
+            ))
+          }
+          value={orders?.price || 0}
+          unit="USDT"
+        />
+      </InputField>
+
+      <InputField>
+        <InputField.Label>Amount</InputField.Label>
+        <InputField.Number
+          step={0.01}
+          type="number"
+          setValue={setAmount}
+          value={amount}
+          unit="BTC"
+        />
+      </InputField>
+    </>
+  );
+
   return (
     <Card
       style={{ gridArea: "orderform" }}
@@ -41,56 +98,14 @@ export default function Orderform() {
         <div className="flex-1 flex justify-between gap-4 mt-1 mb-6">
           <div className="w-1/2 flex flex-col justify-between">
             <div className="flex flex-col gap-2">
-              <InputField>
-                <InputField.Label>Price</InputField.Label>
-                <InputField.Number
-                  step={0.01}
-                  type="number"
-                  setValue={setPrice}
-                  value={price}
-                  unit="USDT"
-                />
-              </InputField>
-
-              <InputField>
-                <InputField.Label>Amount</InputField.Label>
-                <InputField.Number
-                  step={0.01}
-                  type="number"
-                  setValue={setAmount}
-                  value={amount}
-                  unit="BTC"
-                />
-              </InputField>
+              {renderInputFields("buy", buyAmount, setBuyAmount)}
             </div>
-
             <Button variant="buy">Buy</Button>
           </div>
           <div className="w-1/2 flex flex-col justify-between">
             <div className="flex flex-col gap-2">
-              <InputField>
-                <InputField.Label>Price</InputField.Label>
-                <InputField.Number
-                  step={0.01}
-                  type="number"
-                  setValue={setPrice}
-                  value={price}
-                  unit="USDT"
-                />
-              </InputField>
-
-              <InputField>
-                <InputField.Label>Amount</InputField.Label>
-                <InputField.Number
-                  step={0.01}
-                  type="number"
-                  setValue={setAmount}
-                  value={amount}
-                  unit="BTC"
-                />
-              </InputField>
+              {renderInputFields("sell", sellAmount, setSellAmount)}
             </div>
-
             <Button variant="sell">Sell</Button>
           </div>
         </div>

--- a/src/app/trade/[symbol]/_hooks/useSelectOrderContent.ts
+++ b/src/app/trade/[symbol]/_hooks/useSelectOrderContent.ts
@@ -1,0 +1,30 @@
+"use client";
+import { useState } from "react";
+import type { OrderItem } from "@/types/order";
+
+export default function useSelectOrderContent() {
+  const [selectedOrder, setSelectedOrder] = useState<
+    OrderItem & { type: "sell" | "buy"; }
+  >({
+    price: 0,
+    amount: 0,
+    total: 0,
+    type: "sell",
+    sumBTC: 0,
+  });
+
+  const handleSelectOrder = (
+    order: OrderItem,
+    type: "sell" | "buy",
+    target: "price" | "amount" | "total"
+  ) => {
+    setSelectedOrder((prev) => ({
+      ...prev,
+      ...order,
+      type,
+      ...(target === "price" ? { sumBTC: 0 } : {}),
+    }));
+  };
+
+  return { selectedOrder, handleSelectOrder };
+}

--- a/src/app/trade/[symbol]/dummyData.json
+++ b/src/app/trade/[symbol]/dummyData.json
@@ -1,0 +1,128 @@
+{
+  "buy": [
+    { "price": 96211.23, "amount": 0.07903, "total": 7600, "sumBTC": 4.23 },
+    { "price": 96210.14, "amount": 0.05075, "total": 4880, "sumBTC": 2.43 },
+    {
+      "price": 96209.76,
+      "amount": 0.00257,
+      "total": 247.25908,
+      "sumBTC": 0.12
+    },
+    { "price": 96209.75, "amount": 0.07687, "total": 7400, "sumBTC": 3.6 },
+    { "price": 96209.74, "amount": 0.3116, "total": 29980, "sumBTC": 14.98 },
+    { "price": 96209.26, "amount": 0.85818, "total": 82560, "sumBTC": 41.28 },
+    { "price": 96208.67, "amount": 0.23061, "total": 22190, "sumBTC": 10.58 },
+    { "price": 96208.66, "amount": 0.07422, "total": 7140, "sumBTC": 3.4 },
+    { "price": 96208.01, "amount": 0.29611, "total": 28490, "sumBTC": 13.79 },
+    { "price": 96208.0, "amount": 0.0094, "total": 904.3552, "sumBTC": 0.44 },
+    { "price": 96207.55, "amount": 0.51949, "total": 49980, "sumBTC": 24.98 },
+    { "price": 96207.54, "amount": 0.00006, "total": 5.77245, "sumBTC": 0.03 },
+    { "price": 96206.9, "amount": 0.38539, "total": 37080, "sumBTC": 18.5 },
+    { "price": 96206.89, "amount": 0.54, "total": 51950, "sumBTC": 27.0 },
+    { "price": 96206.34, "amount": 0.29499, "total": 28380, "sumBTC": 14.18 },
+    { "price": 96205.81, "amount": 0.07583, "total": 7300, "sumBTC": 3.6 },
+    { "price": 96205.76, "amount": 0.09886, "total": 9510, "sumBTC": 4.74 },
+    { "price": 96205.75, "amount": 0.00054, "total": 51.9511, "sumBTC": 0.27 },
+    { "price": 96205.51, "amount": 0.07268, "total": 6990, "sumBTC": 3.48 },
+    { "price": 96205.5, "amount": 0.15686, "total": 15090, "sumBTC": 7.54 },
+    { "price": 96205.33, "amount": 0.08106, "total": 7800, "sumBTC": 3.9 },
+    { "price": 96205.05, "amount": 0.52386, "total": 50400, "sumBTC": 25.2 },
+    { "price": 96205.03, "amount": 0.25974, "total": 24990, "sumBTC": 12.48 },
+    { "price": 96204.76, "amount": 0.06544, "total": 6300, "sumBTC": 3.1 },
+    { "price": 96204.31, "amount": 0.002, "total": 192.40862, "sumBTC": 0.096 },
+    { "price": 96204.2, "amount": 0.0001, "total": 9.62042, "sumBTC": 0.005 },
+    { "price": 96204.19, "amount": 0.00007, "total": 6.73429, "sumBTC": 0.003 },
+    { "price": 96204.06, "amount": 0.08103, "total": 7800, "sumBTC": 3.9 },
+    {
+      "price": 96204.05,
+      "amount": 0.00085,
+      "total": 81.77344,
+      "sumBTC": 0.405
+    },
+    { "price": 96204.03, "amount": 0.33843, "total": 32560, "sumBTC": 16.28 },
+    { "price": 96204.0, "amount": 0.0094, "total": 904.3176, "sumBTC": 0.44 },
+    { "price": 96203.94, "amount": 0.00008, "total": 7.69632, "sumBTC": 0.004 },
+    { "price": 96203.69, "amount": 0.05365, "total": 5160, "sumBTC": 2.58 },
+    { "price": 96203.61, "amount": 0.07687, "total": 7400, "sumBTC": 3.6 },
+    { "price": 96202.73, "amount": 0.00006, "total": 5.77216, "sumBTC": 0.03 },
+    { "price": 96202.42, "amount": 0.08103, "total": 7800, "sumBTC": 3.9 },
+    { "price": 96202.4, "amount": 0.09696, "total": 9330, "sumBTC": 4.68 },
+    { "price": 96202.18, "amount": 0.00008, "total": 7.69617, "sumBTC": 0.004 },
+    { "price": 96202.01, "amount": 0.14227, "total": 13690, "sumBTC": 6.84 },
+    { "price": 96200.83, "amount": 0.00013, "total": 12.50611, "sumBTC": 0.065 }
+  ],
+  "sell": [
+    { "price": 96274.63, "amount": 0.20752, "total": 19980, "sumBTC": 9.98 },
+    { "price": 96274.56, "amount": 0.25974, "total": 25010, "sumBTC": 12.48 },
+    { "price": 96274.17, "amount": 0.15226, "total": 14660, "sumBTC": 7.3 },
+    { "price": 96273.44, "amount": 0.00008, "total": 7.70188, "sumBTC": 0.004 },
+    { "price": 96272.3, "amount": 0.37214, "total": 35830, "sumBTC": 17.9 },
+    { "price": 96272.0, "amount": 0.1087, "total": 10460, "sumBTC": 5.23 },
+    {
+      "price": 96271.48,
+      "amount": 0.00011,
+      "total": 10.58986,
+      "sumBTC": 0.005
+    },
+    {
+      "price": 96270.79,
+      "amount": 0.01038,
+      "total": 999.2908,
+      "sumBTC": 0.499
+    },
+    { "price": 96270.66, "amount": 0.00006, "total": 5.77624, "sumBTC": 0.03 },
+    { "price": 96270.08, "amount": 0.00006, "total": 5.7762, "sumBTC": 0.03 },
+    { "price": 96269.97, "amount": 0.04, "total": 3850, "sumBTC": 1.9 },
+    { "price": 96269.85, "amount": 0.07824, "total": 7530, "sumBTC": 3.76 },
+    { "price": 96268.56, "amount": 0.0308, "total": 2970, "sumBTC": 1.48 },
+    {
+      "price": 96268.34,
+      "amount": 0.00061,
+      "total": 58.72369,
+      "sumBTC": 0.031
+    },
+    { "price": 96268.0, "amount": 0.0993, "total": 9560, "sumBTC": 4.76 },
+    { "price": 96267.99, "amount": 0.00008, "total": 7.70144, "sumBTC": 0.004 },
+    { "price": 96267.36, "amount": 0.30873, "total": 29720, "sumBTC": 14.86 },
+    { "price": 96266.33, "amount": 0.2386, "total": 22970, "sumBTC": 11.48 },
+    {
+      "price": 96266.32,
+      "amount": 0.00024,
+      "total": 23.10392,
+      "sumBTC": 0.012
+    },
+    { "price": 96265.27, "amount": 0.00006, "total": 5.77592, "sumBTC": 0.03 },
+    { "price": 96264.72, "amount": 0.2, "total": 19250, "sumBTC": 9.6 },
+    { "price": 96264.71, "amount": 0.0003, "total": 28.87941, "sumBTC": 0.015 },
+    { "price": 96264.02, "amount": 0.03642, "total": 3510, "sumBTC": 1.72 },
+    { "price": 96264.0, "amount": 0.09938, "total": 9570, "sumBTC": 4.76 },
+    {
+      "price": 96263.99,
+      "amount": 0.00024,
+      "total": 23.10336,
+      "sumBTC": 0.012
+    },
+    {
+      "price": 96263.98,
+      "amount": 0.00024,
+      "total": 23.10336,
+      "sumBTC": 0.012
+    },
+    { "price": 96263.97, "amount": 0.0001, "total": 9.6264, "sumBTC": 0.005 },
+    { "price": 96262.96, "amount": 0.0001, "total": 9.6263, "sumBTC": 0.005 },
+    { "price": 96262.12, "amount": 0.0001, "total": 9.62621, "sumBTC": 0.005 },
+    { "price": 96262.11, "amount": 0.0001, "total": 9.62621, "sumBTC": 0.005 },
+    { "price": 96261.05, "amount": 0.00006, "total": 5.77566, "sumBTC": 0.03 },
+    { "price": 96260.66, "amount": 0.23511, "total": 22630, "sumBTC": 11.3 },
+    {
+      "price": 96260.65,
+      "amount": 0.00945,
+      "total": 909.66314,
+      "sumBTC": 0.472
+    },
+    { "price": 96260.64, "amount": 0.00016, "total": 15.4017, "sumBTC": 0.008 },
+    { "price": 96260.55, "amount": 0.12975, "total": 12430, "sumBTC": 6.24 },
+    { "price": 96260.54, "amount": 0.00006, "total": 5.77554, "sumBTC": 0.03 },
+    { "price": 96260.53, "amount": 0.00006, "total": 5.77554, "sumBTC": 0.04 }
+  ]
+}

--- a/src/app/trade/[symbol]/page.tsx
+++ b/src/app/trade/[symbol]/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Chart from "./_components/Chart";
 import Footer from "./_components/Footer";
 import Market from "./_components/Market";
@@ -7,8 +8,11 @@ import Orderform from "./_components/Orderform";
 import SubHeader from "./_components/SubHeader";
 import Trades from "./_components/Trades";
 import UserInfo from "./_components/UserInfo";
+import useSelectOrderContent from "./_hooks/useSelectOrderContent";
 
 export default function Page() {
+  const { selectedOrder, handleSelectOrder } = useSelectOrderContent();
+
   return (
     <main className="relative flex justify-center bg-[var(--color-TradeBg)]">
       <div
@@ -29,12 +33,12 @@ export default function Page() {
         }}
       >
         <SubHeader />
-        <OrderBook />
+        <OrderBook onSelectOrder={handleSelectOrder} />
         <Chart />
         <Market />
         <Trades />
         <MarketActivity />
-        <Orderform />
+        <Orderform selectedOrder={selectedOrder} />
         <UserInfo />
       </div>
 

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -3,6 +3,7 @@ import {
   Dispatch,
   forwardRef,
   SetStateAction,
+  useEffect,
   useState,
 } from "react";
 import InputArrowPad from "./InputNumberArrowPad";
@@ -38,6 +39,10 @@ const InputNumber = forwardRef<HTMLInputElement, InputProps<number>>(
       setCurrentValue(value);
       setValue(value);
     };
+
+    useEffect(() => {
+      setCurrentValue(Number(props.value));
+    }, [props.value]);
 
     return (
       <>

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,0 +1,8 @@
+export interface OrderItem {
+  price: number;
+  amount: number;
+  total: number;
+  sumBTC: number;
+}
+
+export type OrderBookFilter = "all" | "buy" | "sell";


### PR DESCRIPTION
## OrderBook 클릭 기능 구현
- 작업 시간: 기능 구현 기준 1시간 20분
  - 3시반~4시 50분(recoil 트러블 슈팅/실패)
  - 5시~6시 20분(코드 작업)

## 리뷰어에게 전할 내용
- Recoil을 설치하여 전역 상태 관리를 진행하고자 하였으나 RecoilRoot 관련 오류가 발생했고, 1시간 20분 동안 오류 원인을 파악해보려 했지만 진전이 전혀 없었습니다.
  - 관련 내용: https://www.notion.so/dusunax/Order-Book-14a41dabbb6580a4a23cfe40bacd0dfe?pvs=4#14c41dabbb65808cb06dd99814e40f15
- 라이브러리 설정에 시간이 더 소요될 것으로 예상되어, page단에 커스텀 훅을 추가하고 카드에 props로 전달하는 방식으로 구현했습니다. 
  - 자식 카드에서 불필요한 리랜더링 생기지 않도록 다른 카드의 메모이제이션을 신경써 보겠습니다.
  - page가 클라이언트 컴포넌트가 되었으나, 실시간 정보를 사용하는 페이지 특성 상 초기 JavaScript 파일을 받아오는 방식이 SPA와 유사하더라도 큰 성능 저하가 없을 것으로 생각합니다.

## 시연 영상
https://github.com/user-attachments/assets/ea86efcf-ca11-42d6-b984-47e99a584f0b

