### PR TITLE
feat: 푸터에 연결상태 확인 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.61.4",
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-query-devtools": "4",
     "@types/numeral": "^2.0.5",
     "dayjs": "^1.11.13",
     "lightweight-charts": "^4.2.1",

--- a/src/app/[lang]/trade/[symbol]/_components/Footer.tsx
+++ b/src/app/[lang]/trade/[symbol]/_components/Footer.tsx
@@ -1,7 +1,60 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import ConnectionStatus from "./Footer/ConnectionStatus";
+
+export type ConnectionStatusType =
+  | "Stable Connection"
+  | "Unstable Connection"
+  | "Disconnected"
+  | "Connecting";
+
+const TIMEOUT_DURATION = 500;
+
+const ping = async () => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_DURATION);
+
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/ping`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    return { ok: response.ok, aborted: false };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      console.log("접속 시간 초과");
+      return { ok: false, aborted: true };
+    }
+    return { ok: false, aborted: false };
+  }
+};
+
 export default function Footer() {
+  const [status, setStatus] = useState<ConnectionStatusType>("Connecting");
+
+  const { data, isFetching } = useQuery({
+    queryKey: ["ping"],
+    queryFn: () => ping(),
+    staleTime: 0,
+    refetchInterval: status === "Stable Connection" ? 30 * 1000 : 5 * 1000,
+  });
+
+  useEffect(() => {
+    if (data === undefined || isFetching) {
+      setStatus("Connecting");
+    } else if (data.aborted) {
+      setStatus("Unstable Connection");
+    } else {
+      setStatus(data.ok ? "Stable Connection" : "Disconnected");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
   return (
-    <footer className="fixed bottom-0 w-full bg-[var(--color-BasicBg)] border-t-4 border-[var(--color-TradeBg)] rounded-md">
-      Footer
+    <footer className="h-8 fixed items-center bottom-0 w-full bg-[var(--color-BasicBg)] border-t-4 border-[var(--color-TradeBg)] rounded-md px-4 pb-1">
+      <ConnectionStatus status={status} />
     </footer>
   );
 }

--- a/src/app/[lang]/trade/[symbol]/_components/Footer/ConnectionStatus.tsx
+++ b/src/app/[lang]/trade/[symbol]/_components/Footer/ConnectionStatus.tsx
@@ -1,0 +1,66 @@
+import { ConnectionStatusType } from "../Footer";
+
+const getColor = (status: ConnectionStatusType) => {
+  return status === "Stable Connection"
+    ? "#0ECB81"
+    : status === "Disconnected"
+    ? "#B7BDC6"
+    : "#F0B90B";
+};
+
+export default function ConnectionStatus({
+  status,
+}: {
+  status: ConnectionStatusType;
+}) {
+  const textColor = getColor(status);
+
+  return (
+    <div
+      className={`h-full flex items-center gap-1 text-xs`}
+      style={{ color: textColor }}
+    >
+      <ConnectionSvg status={status} />
+      {status}
+    </div>
+  );
+}
+
+function ConnectionSvg({ status }: { status: ConnectionStatusType }) {
+  const color = getColor(status);
+
+  return (
+    <svg
+      width="12"
+      height="10"
+      viewBox="0 0 12 10"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M2 6.33331H0V9.66665H2V6.33331Z"
+        fill={color}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5.33333 4.33331H3.33333V9.66665H5.33333V4.33331Z"
+        fill={color}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6.66667 2.33331H8.66667V9.66665H6.66667V2.33331Z"
+        fill={color}
+      ></path>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 0.333313H10V9.66665H12V0.333313Z"
+        fill={color}
+      ></path>
+    </svg>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { binancePlex } from "./fonts";
 import type { Metadata } from "next";
 import "./globals.css";
+import { TanstackQueryClientProvider as QueryClientProvider } from "@/components/QueryClientProvider";
 
 export const metadata: Metadata = {
   title: "Binance Plex Front Test",
@@ -17,8 +18,10 @@ export default async function RootLayout({
     .join(" ");
 
   return (
-    <html lang="en" className={binancePlexVariables}>
-      <body className="antialiased font-binancePlex">{children}</body>
-    </html>
+    <QueryClientProvider>
+      <html lang="en" className={binancePlexVariables}>
+        <body className="antialiased font-binancePlex">{children}</body>
+      </html>
+    </QueryClientProvider>
   );
 }

--- a/src/components/QueryClientProvider.tsx
+++ b/src/components/QueryClientProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export const TanstackQueryClientProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      })
+  );
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,17 +1320,33 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tanstack/query-core@5.61.4":
-  version "5.61.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.61.4.tgz#ad331f94824fe1087dc505a9f62dc84e841a6a28"
-  integrity sha512-rsnemyhPvEG4ViZe0R2UQDM8NgQS/BNC5/Gf9RTs0TKN5thUhPUwnL2anWG4jxAGKFyDfvG7PXbx6MRq3hxi1w==
-
-"@tanstack/react-query@^5.61.4":
-  version "5.61.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.61.4.tgz#4e41088f542f9c2f23b2e84fd547572741e46a78"
-  integrity sha512-Nh5+0V4fRVShSeDHFTVvzJrvwTdafIvqxyZUrad71kJWL7J+J5Wrd/xcHTWfSL1mR/9eoufd2roXOpL3F16ECA==
+"@tanstack/match-sorter-utils@^8.7.0":
+  version "8.19.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz#dacf772b5d94f4684f10dbeb2518cf72dccab8a5"
+  integrity sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==
   dependencies:
-    "@tanstack/query-core" "5.61.4"
+    remove-accents "0.5.0"
+
+"@tanstack/query-core@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.62.0.tgz#94022c9fde3b8c60e69828b726bd0df535dcacf9"
+  integrity sha512-sx38bGrqF9bop92AXOvzDr0L9fWDas5zXdPglxa9cuqeVSWS7lY6OnVyl/oodfXjgOGRk79IfCpgVmxrbHuFHg==
+
+"@tanstack/react-query-devtools@4":
+  version "4.36.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.36.1.tgz#7e63601135902a993ca9af73507b125233b1554e"
+  integrity sha512-WYku83CKP3OevnYSG8Y/QO9g0rT75v1om5IvcWUwiUZJ4LanYGLVCZ8TdFG5jfsq4Ej/lu2wwDAULEUnRIMBSw==
+  dependencies:
+    "@tanstack/match-sorter-utils" "^8.7.0"
+    superjson "^1.10.0"
+    use-sync-external-store "^1.2.0"
+
+"@tanstack/react-query@^5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.62.0.tgz#db7d4ec58a0db69b105e2d8bd249acfb20653825"
+  integrity sha512-tj2ltjAn2a3fs+Dqonlvs6GyLQ/LKVJE2DVSYW+8pJ3P6/VCVGrfqv5UEchmlP7tLOvvtZcOuSyI2ooVlR5Yqw==
+  dependencies:
+    "@tanstack/query-core" "5.62.0"
 
 "@trysound/sax@0.2.0":
   version "0.2.0"
@@ -1830,6 +1846,13 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+copy-anything@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
+  integrity sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==
+  dependencies:
+    is-what "^4.1.8"
 
 core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   version "3.39.0"
@@ -2957,6 +2980,11 @@ is-weakset@^2.0.3:
     call-bind "^1.0.7"
     get-intrinsic "^1.2.4"
 
+is-what@^4.1.8:
+  version "4.1.16"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.16.tgz#1ad860a19da8b4895ad5495da3182ce2acdd7a6f"
+  integrity sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -3647,6 +3675,11 @@ regjsparser@^0.12.0:
   dependencies:
     jsesc "~3.0.2"
 
+remove-accents@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.5.0.tgz#77991f37ba212afba162e375b627631315bed687"
+  integrity sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -3958,6 +3991,13 @@ sucrase@^3.35.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
+superjson@^1.10.0:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.13.3.tgz#3bd64046f6c0a47062850bb3180ef352a471f930"
+  integrity sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==
+  dependencies:
+    copy-anything "^3.0.2"
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -4186,6 +4226,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## feat: 푸터에 연결상태 확인 기능 추가

- 작업 시간: 8시반~10시 (1시간 30분)
- 기능: 페이지 좌측 하단, 푸터 내부의 연결 상태 컴포넌트 구현
   ![image](https://github.com/user-attachments/assets/903da2dd-8147-4acc-9cda-96fce68578e8)
- 작업:
   - tanstack query 초기 설정
   - API ping 요청
   - ConnectionStatus.tsx 컴포넌트 구현

## 재연결 기능 (tanstack query의 refetchInterval 사용)
- 안정적인 연결 상태일 때: 30초 마다 refetch하여 정상 연결 확인
- 연결 중 혹은 미연결 상태일 때: 5초 마다 refetch하여 연결 시도

## 연결 상태

상태 | 설명
-- | --
🟢 Stable Connection | Ping 요청 응답이 정상적일 때
🟡 Connecting | 요청을 보내기 전이거나, 요청을 보내는 중일 때
🟢 Unstable Connection | ping 요청이 500ms 내에 응답되지 않을 때 (aborted)
🔘 Disconnected | ping 요청 응답이 에러일 때

## 시연 영상

https://github.com/user-attachments/assets/0086ad83-904a-4f10-90e7-44879fb65d30

